### PR TITLE
Add proactive session refresh hook to prevent token expiration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useState, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { Spinner } from 'react-bootstrap';
+import { useSessionRefresh } from './hooks/useSessionRefresh';
 
 const HomePage = lazy(() => import('./pages/HomePage'));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
@@ -32,6 +33,8 @@ function ProtectedRoute({ children }) {
 }
 
 function App() {
+  useSessionRefresh();
+
   const [toasterTheme, setToasterTheme] = useState(() => {
     return document.documentElement.getAttribute('data-theme') || 'dark';
   });

--- a/src/hooks/useSessionRefresh.js
+++ b/src/hooks/useSessionRefresh.js
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import axios from 'axios';
+import api from '../services/api';
+
+export function useSessionRefresh() {
+  useEffect(() => {
+    const refresh = async () => {
+      const refreshToken = localStorage.getItem('refreshToken');
+      const authToken = localStorage.getItem('authToken');
+
+      if (!refreshToken || !authToken) return;
+
+      let expiresAt;
+      try {
+        const payload = JSON.parse(atob(authToken.split('.')[1]));
+        expiresAt = payload.exp * 1000;
+      } catch {
+        // Token malformado — deixa o interceptor reativo cuidar
+        return;
+      }
+
+      const fiveMinutes = 5 * 60 * 1000;
+      if (expiresAt - Date.now() >= fiveMinutes) return;
+
+      try {
+        const response = await axios.post(`${api.defaults.baseURL}/auth/refresh`, {
+          refreshToken,
+        });
+        const { token: newToken, refreshToken: newRefreshToken } = response.data;
+        localStorage.setItem('authToken', newToken);
+        localStorage.setItem('refreshToken', newRefreshToken);
+        api.defaults.headers.common['Authorization'] = 'Bearer ' + newToken;
+      } catch {
+        if (!window.location.pathname.includes('/login')) {
+          localStorage.removeItem('authToken');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+        }
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
+    };
+  }, []);
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -102,6 +102,7 @@ api.interceptors.response.use(
           isRefreshing = false;
         }
       } else {
+        isRefreshing = false;
         if (!window.location.pathname.includes('/login')) {
           toast.error(i18n.t('api.sessionExpired'));
           localStorage.removeItem('authToken');


### PR DESCRIPTION
## Summary
This PR implements a proactive session refresh mechanism that automatically refreshes authentication tokens before they expire, improving user experience by preventing unexpected session timeouts.

## Key Changes
- **New `useSessionRefresh` hook** (`src/hooks/useSessionRefresh.js`): 
  - Monitors token expiration by decoding JWT payload
  - Automatically refreshes tokens when they're within 5 minutes of expiration
  - Listens to visibility change and window focus events to refresh tokens when the app regains focus
  - Handles refresh failures by redirecting to login page
  - Properly cleans up event listeners on unmount

- **Integrated hook into App component** (`src/App.jsx`):
  - Added `useSessionRefresh()` call at the root level to enable proactive refresh globally

- **Fixed race condition in API interceptor** (`src/services/api.js`):
  - Added missing `isRefreshing = false` reset in the error handler to prevent the interceptor from getting stuck in a refreshing state

## Implementation Details
- Token expiration is determined by parsing the JWT's `exp` claim
- Refresh is triggered when token expiration is within 5 minutes
- The hook responds to visibility changes and window focus events, ensuring tokens are refreshed when users return to the app
- Malformed tokens are gracefully handled without blocking the refresh flow
- The interceptor's `isRefreshing` flag is now properly reset on all code paths, preventing potential deadlocks

https://claude.ai/code/session_017DqZC998eBTa4Pf3MYCLcu