### PR TITLE
Refactor React vendor chunk grouping in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,14 @@ export default defineConfig({
         // independently and parse in parallel instead of one giant bundle.
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined;
+          // React core must be grouped first so every other chunk that
+          // depends on it resolves to the same module instance.
+          if (
+            id.includes('/node_modules/react/') ||
+            id.includes('/node_modules/react-dom/') ||
+            id.includes('/node_modules/react-router') ||
+            id.includes('/node_modules/scheduler/')
+          ) return 'react-vendor';
           if (id.includes('recharts') || id.includes('d3-') || id.includes('victory-vendor')) return 'recharts';
           if (id.includes('react-datepicker')) return 'datepicker';
           if (id.includes('date-fns')) return 'datefns';
@@ -21,7 +29,6 @@ export default defineConfig({
           if (id.includes('react-bootstrap') || id.includes('@restart')) return 'bootstrap';
           if (id.includes('i18next')) return 'i18n';
           if (id.includes('sockjs') || id.includes('stomp')) return 'ws';
-          if (id.includes('/react-dom/') || id.includes('/react-router') || id.includes('/scheduler/')) return 'react-vendor';
           return undefined;
         },
       },


### PR DESCRIPTION
## Summary
Reorganized the manual chunk configuration in `vite.config.js` to prioritize React core dependencies by grouping them first in the chunking logic.

## Key Changes
- Moved React vendor chunk detection to the beginning of the `manualChunks` function, before other library checks
- Expanded React vendor grouping to explicitly include:
  - `react`
  - `react-dom`
  - `react-router`
  - `scheduler`
- Removed the duplicate React vendor chunk rule that was previously at the end of the function

## Implementation Details
This change ensures that React core modules and their dependents are resolved to the same module instance by processing them first in the chunking strategy. By placing this check before other vendor libraries (recharts, datepicker, etc.), we guarantee that any chunk depending on React will reference the same bundled React core, preventing potential issues with multiple React instances in the application.

https://claude.ai/code/session_017dd2xECEjm65PomgPxpSD8