### PR TITLE
fix(build): agrupa libs react-dependentes no react-vendor para evitar ciclos entre chunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,22 +13,28 @@ export default defineConfig({
         // independently and parse in parallel instead of one giant bundle.
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined;
-          // React core must be grouped first so every other chunk that
-          // depends on it resolves to the same module instance.
+          // Libs que NAO dependem de react sao seguras em chunks separados.
+          if (id.includes('recharts') || id.includes('d3-') || id.includes('victory-vendor')) return 'recharts';
+          if (id.includes('date-fns')) return 'datefns';
+          if (id.includes('@dnd-kit')) return 'dndkit';
+          if (id.includes('flag-icons')) return 'flag-icons';
+          if (id.includes('i18next')) return 'i18n';
+          if (id.includes('sockjs') || id.includes('stomp')) return 'ws';
+          // Tudo que toca em React fica junto para evitar ciclos entre chunks:
+          // Rollup move helpers compartilhados entre chunks e cria
+          // dependencias circulares (react-vendor <-> bootstrap), o que faz
+          // createContext/useLayoutEffect serem `undefined` em producao.
           if (
             id.includes('/node_modules/react/') ||
             id.includes('/node_modules/react-dom/') ||
             id.includes('/node_modules/react-router') ||
-            id.includes('/node_modules/scheduler/')
+            id.includes('/node_modules/scheduler/') ||
+            id.includes('/node_modules/react-is/') ||
+            id.includes('/node_modules/prop-types/') ||
+            id.includes('react-bootstrap') ||
+            id.includes('@restart') ||
+            id.includes('react-datepicker')
           ) return 'react-vendor';
-          if (id.includes('recharts') || id.includes('d3-') || id.includes('victory-vendor')) return 'recharts';
-          if (id.includes('react-datepicker')) return 'datepicker';
-          if (id.includes('date-fns')) return 'datefns';
-          if (id.includes('@dnd-kit')) return 'dndkit';
-          if (id.includes('flag-icons')) return 'flag-icons';
-          if (id.includes('react-bootstrap') || id.includes('@restart')) return 'bootstrap';
-          if (id.includes('i18next')) return 'i18n';
-          if (id.includes('sockjs') || id.includes('stomp')) return 'ws';
           return undefined;
         },
       },


### PR DESCRIPTION
## Resumo

Corrige `Uncaught TypeError: Cannot read properties of undefined (reading 'createContext')` em `bootstrap-*.js` em produção (mesma classe do bug anterior com `useLayoutEffect` em `datepicker-*.js`).

## Causa raiz

O `manualChunks` separava `react-bootstrap` + `@restart` em um chunk `bootstrap` e `react-datepicker` em outro. Rollup hoistava helpers compartilhados (ex.: função de unwrap de default export) para um desses chunks mantendo um `import` deles de volta em `react-vendor`, gerando ciclo `react-vendor ↔ bootstrap`. Em produção, `react-vendor` avaliava primeiro, puxava do `bootstrap`, que tentava usar `createContext` antes de `react` terminar de inicializar → `undefined`.

## Fix

- Chunks separados **só** para libs sem React no grafo: `recharts` (+ `d3-`, `victory-vendor`), `date-fns`, `@dnd-kit`, `flag-icons`, `i18next`, `sockjs`/`stomp`.
- Tudo que toca em React fica junto em `react-vendor`: `react`, `react-dom`, `scheduler`, `react-router`, `react-is`, `prop-types`, `react-bootstrap`, `@restart`, `react-datepicker`.

Isso elimina a possibilidade de ciclo entre chunks vendor, independente de qual helper o Rollup decidir hoistar.

## Trade-off

`react-vendor` ficou ~520 KB (145 KB gzip) vs ~220 KB antes — é cache de longo prazo, baixa só uma vez. Recharts (115 KB gzip) e demais leaves continuam separados.

## Teste

- [x] `npm run build` passa
- [x] Verificado nos chunks gerados que nenhum vendor chunk importa de volta para `react-vendor`
- [ ] Validar em produção após deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_017dd2xECEjm65PomgPxpSD8)_