### PR TITLE
fix(build): inclui react-i18next no react-vendor para evitar createContext undefined

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,17 +13,12 @@ export default defineConfig({
         // independently and parse in parallel instead of one giant bundle.
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined;
-          // Libs que NAO dependem de react sao seguras em chunks separados.
-          if (id.includes('recharts') || id.includes('d3-') || id.includes('victory-vendor')) return 'recharts';
-          if (id.includes('date-fns')) return 'datefns';
-          if (id.includes('@dnd-kit')) return 'dndkit';
-          if (id.includes('flag-icons')) return 'flag-icons';
-          if (id.includes('i18next')) return 'i18n';
-          if (id.includes('sockjs') || id.includes('stomp')) return 'ws';
           // Tudo que toca em React fica junto para evitar ciclos entre chunks:
           // Rollup move helpers compartilhados entre chunks e cria
-          // dependencias circulares (react-vendor <-> bootstrap), o que faz
-          // createContext/useLayoutEffect serem `undefined` em producao.
+          // dependencias circulares (react-vendor <-> outro chunk). O ciclo
+          // so crasha se o outro chunk fizer createContext/useLayoutEffect
+          // no top-level (react-bootstrap, react-datepicker, react-i18next),
+          // mas e mais seguro colapsar tudo que importa React aqui.
           if (
             id.includes('/node_modules/react/') ||
             id.includes('/node_modules/react-dom/') ||
@@ -33,8 +28,16 @@ export default defineConfig({
             id.includes('/node_modules/prop-types/') ||
             id.includes('react-bootstrap') ||
             id.includes('@restart') ||
-            id.includes('react-datepicker')
+            id.includes('react-datepicker') ||
+            id.includes('react-i18next')
           ) return 'react-vendor';
+          // Libs que NAO dependem de react sao seguras em chunks separados.
+          if (id.includes('recharts') || id.includes('d3-') || id.includes('victory-vendor')) return 'recharts';
+          if (id.includes('date-fns')) return 'datefns';
+          if (id.includes('@dnd-kit')) return 'dndkit';
+          if (id.includes('flag-icons')) return 'flag-icons';
+          if (id.includes('i18next')) return 'i18n';
+          if (id.includes('sockjs') || id.includes('stomp')) return 'ws';
           return undefined;
         },
       },


### PR DESCRIPTION
## Resumo

Terceira ocorrência do mesmo padrão de bug em produção:
`Uncaught TypeError: Cannot read properties of undefined (reading 'createContext')` em `i18n-*.js`.

Anteriormente o mesmo crash apareceu em `datepicker-*.js` (useLayoutEffect) e `bootstrap-*.js` (createContext). Cada fix isolado deslocou o problema para a próxima lib React-dependente em chunk separado.

## Causa raiz (definitiva)

Rollup hoista helpers internos compartilhados (ex.: função de unwrap de default export) para algum chunk vendor arbitrário. Quando `react-vendor` também usa esse helper, ele acaba importando do outro chunk — criando ciclo `react-vendor ↔ chunk-X`. Se `chunk-X` chama `React.createContext` (ou hook) no **top-level do módulo**, o ciclo crasha porque `react` ainda está mid-eval quando o outro chunk roda.

Bibliotecas React-dependentes que fazem isso no top-level:
- `react-bootstrap` (fix anterior)
- `react-datepicker` (fix anterior)
- `react-i18next` (este fix)

`@dnd-kit` e similares também dependem de React mas só tocam hooks dentro de funções, então não crasham — ficam em chunks separados sem problema.

## Fix

Adiciona `react-i18next` ao chunk `react-vendor`. `i18next` puro (sem React) continua no chunk `i18n`.

## Teste

- [x] `npm run build` passa
- [x] Confirmado que `react-vendor` não importa de nenhum outro chunk (sem ciclos)

---
_Generated by [Claude Code](https://claude.ai/code/session_017dd2xECEjm65PomgPxpSD8)_