### PR TITLE
fix(kanban): autoscroll lento ao arrastar card

### DIFF
--- a/src/components/KanbanColumn.jsx
+++ b/src/components/KanbanColumn.jsx
@@ -28,7 +28,6 @@ function KanbanColumn({ title, status, color, tasks = [], projects = [], onEdit,
     overflowY: 'auto',
     overflowX: 'hidden',
     flexGrow: 1,
-    scrollBehavior: 'smooth'
   };
 
   const taskIds = tasks.map(task => task.id);

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -533,6 +533,9 @@ export default function DashboardPage() {
     useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } })
   );
 
+  // Snappier autoscroll while dragging — defaults are too gentle and feel laggy.
+  const dndAutoScroll = { threshold: { x: 0.15, y: 0.18 }, acceleration: 30, interval: 5 };
+
   // Smooth settle when a card is dropped; keep the original slot hidden until
   // the overlay finishes animating back into place.
   const dropAnimation = {
@@ -868,7 +871,7 @@ export default function DashboardPage() {
             </div>}
           </header>
 
-          <DndContext sensors={sensors} collisionDetection={closestCorners} onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
+          <DndContext sensors={sensors} collisionDetection={closestCorners} autoScroll={dndAutoScroll} onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
             <div style={{ flex: 1, minHeight: 0 }}>
               <h2 className="visually-hidden">{t('dashboard.title')}</h2>
               {renderDashboardContent()}


### PR DESCRIPTION
## Summary
- Remove `scrollBehavior: 'smooth'` do container scrollável das colunas do Kanban.
- Adiciona configuração de `autoScroll` no `DndContext` (`acceleration: 30`, threshold um pouco mais cedo).

## Contexto
Ao segurar um card e arrastar para cima/baixo dentro de uma coluna, o auto-scroll do `@dnd-kit` ficava extremamente lento. Causa: o container das colunas tinha `scrollBehavior: 'smooth'`, e o `@dnd-kit` dispara dezenas de pequenos incrementos de `scrollTop` por segundo — o navegador animava cada um deles e os tweens se acumulavam, deixando o scroll arrastado mesmo com o cursor colado na borda. Com smooth removido e `acceleration` calibrado para 30 (default é 10), o auto-scroll responde imediatamente.

## Test plan
- [ ] Arrastar card pra cima/baixo dentro da mesma coluna e confirmar que o auto-scroll é responsivo
- [ ] Repetir arrastando entre colunas diferentes
- [ ] Verificar mobile (TouchSensor) — auto-scroll continua funcionando ao chegar nas bordas
- [ ] Confirmar que `scrollIntoView` programático (se existir) não foi afetado

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8ELPApqnjiv13B1QK2bWb)_