### PR TITLE
feat(mcp): OAuth consent page + connector-first MCP panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ const AuthCallback = lazy(() => import('./pages/AuthCallback'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const InviteAcceptPage = lazy(() => import('./pages/InviteAcceptPage'));
 const LegalPage = lazy(() => import('./pages/LegalPage'));
+const OAuthConsent = lazy(() => import('./pages/OAuthConsent'));
 
 const LoadingFallback = () => (
   <div style={{
@@ -83,6 +84,7 @@ function App() {
           />
           
           <Route path="/invite/:token" element={<InviteAcceptPage />} />
+          <Route path="/oauth/consent" element={<OAuthConsent />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Suspense>

--- a/src/components/McpModal.jsx
+++ b/src/components/McpModal.jsx
@@ -6,10 +6,14 @@ import Clipboard from 'react-bootstrap-icons/dist/icons/clipboard';
 import Trash from 'react-bootstrap-icons/dist/icons/trash';
 import PlusLg from 'react-bootstrap-icons/dist/icons/plus-lg';
 import ShieldLock from 'react-bootstrap-icons/dist/icons/shield-lock';
+import ChevronDown from 'react-bootstrap-icons/dist/icons/chevron-down';
+import ChevronRight from 'react-bootstrap-icons/dist/icons/chevron-right';
 import { toast } from 'sonner';
 import api from '../services/api';
 
-const SSE_URL = `${api.defaults.baseURL}/mcp/sse`;
+// Streamable HTTP endpoint — what the native "add custom connector" (OAuth) flow speaks, and what
+// mcp-remote (legacy dt_mcp_ fallback) also connects to.
+const MCP_URL = `${api.defaults.baseURL}/mcp`;
 
 function buildSnippet(token) {
   return JSON.stringify(
@@ -17,7 +21,7 @@ function buildSnippet(token) {
       mcpServers: {
         dailytracker: {
           command: 'npx',
-          args: ['-y', 'mcp-remote', SSE_URL, '--header', `Authorization: Bearer ${token}`],
+          args: ['-y', 'mcp-remote', MCP_URL, '--header', `Authorization: Bearer ${token}`],
         },
       },
     },
@@ -34,17 +38,24 @@ export default function McpModal({ show, handleClose }) {
   const [expiresInDays, setExpiresInDays] = useState('');
   const [creating, setCreating] = useState(false);
   const [newToken, setNewToken] = useState(null); // plaintext, shown once
+  const [grants, setGrants] = useState(null);      // authorized OAuth apps
+  const [legacyOpen, setLegacyOpen] = useState(false);
 
   useEffect(() => {
     if (show) {
       setNewToken(null);
-      load();
+      setLegacyOpen(false);
+      loadGrants();
     }
   }, [show]);
 
   const load = () => api.get('/api/mcp/tokens')
     .then(res => setTokens(res.data))
     .catch(() => setTokens([]));
+
+  const loadGrants = () => api.get('/api/oauth/authorizations')
+    .then(res => setGrants(res.data))
+    .catch(() => setGrants([]));
 
   const copy = async (text, okMsg) => {
     try {
@@ -85,6 +96,23 @@ export default function McpModal({ show, handleClose }) {
     } catch {
       /* interceptor toasts the error */
     }
+  };
+
+  const handleRevokeGrant = async (id) => {
+    if (!window.confirm(t('mcp.grantRevokeConfirm'))) return;
+    try {
+      await api.delete(`/api/oauth/authorizations/${id}`);
+      toast.success(t('mcp.grantRevoked'));
+      loadGrants();
+    } catch {
+      /* interceptor toasts the error */
+    }
+  };
+
+  const toggleLegacy = () => {
+    const opening = !legacyOpen;
+    setLegacyOpen(opening);
+    if (opening && tokens === null) load();
   };
 
   const fmtDate = (iso) => (iso ? new Date(iso).toLocaleDateString() : null);
@@ -149,6 +177,13 @@ export default function McpModal({ show, handleClose }) {
     gap: '0.35rem',
     fontSize: '0.78rem',
   };
+  const stepList = {
+    color: 'var(--text-secondary)',
+    fontSize: '0.83rem',
+    lineHeight: 1.6,
+    margin: '0 0 0.6rem',
+    paddingLeft: '1.1rem',
+  };
 
   return (
     <Modal show={show} onHide={handleClose} centered size="lg" contentClassName="border-0 bg-transparent">
@@ -165,116 +200,182 @@ export default function McpModal({ show, handleClose }) {
             {t('mcp.subtitle')}
           </p>
 
-          {/* One-time new token banner */}
-          {newToken && (
-            <div style={{ ...card, borderColor: 'var(--accent-border)', background: 'var(--accent-subtle)' }}>
-              <h3 style={{ ...sectionTitle, marginBottom: '0.35rem' }}>{t('mcp.tokenCreatedTitle')}</h3>
-              <p style={{ color: 'var(--text-secondary)', fontSize: '0.82rem', margin: '0 0 0.6rem' }}>
-                {t('mcp.tokenCreatedWarning')}
-              </p>
-              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                <code style={{ ...codeBox, flex: 1, whiteSpace: 'nowrap' }}>{newToken}</code>
-                <button style={iconBtn} onClick={() => copy(newToken, t('mcp.tokenCopied'))}>
-                  <Clipboard size={13} /> {t('mcp.copy')}
-                </button>
-              </div>
-              <button style={{ ...iconBtn, marginTop: '0.6rem' }} onClick={() => setNewToken(null)}>
-                {t('mcp.dismiss')}
-              </button>
-            </div>
-          )}
-
-          {/* Connection */}
-          <div style={card}>
-            <h3 style={sectionTitle}>{t('mcp.connectionTitle')}</h3>
+          {/* ── Primary: native OAuth connector ─────────────────────────────── */}
+          <div style={{ ...card, borderColor: 'var(--accent-border)' }}>
+            <h3 style={sectionTitle}>{t('mcp.connectTitle')}</h3>
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.82rem', margin: '0 0 0.7rem' }}>
+              {t('mcp.connectHelp')}
+            </p>
             <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem', display: 'block', marginBottom: '0.3rem' }}>
               {t('mcp.endpointLabel')}
             </label>
             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.9rem' }}>
-              <code style={{ ...codeBox, flex: 1, whiteSpace: 'nowrap' }}>{SSE_URL}</code>
-              <button style={iconBtn} onClick={() => copy(SSE_URL)}><Clipboard size={13} /></button>
+              <code style={{ ...codeBox, flex: 1, whiteSpace: 'nowrap' }}>{MCP_URL}</code>
+              <button style={iconBtn} onClick={() => copy(MCP_URL)}><Clipboard size={13} /></button>
             </div>
-            <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem', display: 'block', marginBottom: '0.3rem' }}>
-              {t('mcp.snippetTitle')}
-            </label>
-            <p style={{ color: 'var(--text-muted)', fontSize: '0.78rem', margin: '0 0 0.4rem' }}>{t('mcp.snippetHelp')}</p>
-            <div style={{ position: 'relative' }}>
-              <pre style={codeBox}>{buildSnippet(newToken || t('mcp.tokenPlaceholder'))}</pre>
-              <button
-                style={{ ...iconBtn, position: 'absolute', top: 8, right: 8 }}
-                onClick={() => copy(buildSnippet(newToken || t('mcp.tokenPlaceholder')))}
-              >
-                <Clipboard size={13} /> {t('mcp.copy')}
-              </button>
-            </div>
+            <ol style={stepList}>
+              <li>{t('mcp.connectStep1')}</li>
+              <li>{t('mcp.connectStep2')}</li>
+              <li>{t('mcp.connectStep3')}</li>
+            </ol>
           </div>
 
-          {/* Create token */}
+          {/* ── Authorized apps (OAuth grants) ──────────────────────────────── */}
           <div style={card}>
-            <h3 style={sectionTitle}>{t('mcp.newTokenTitle')}</h3>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem', alignItems: 'flex-end' }}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', flex: '1 1 200px' }}>
-                <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>{t('mcp.labelField')}</label>
-                <input style={input} value={label} onChange={(e) => setLabel(e.target.value)} placeholder={t('mcp.labelPlaceholder')} />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', width: 140 }}>
-                <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>{t('mcp.expiresField')}</label>
-                <input style={input} type="number" min="1" value={expiresInDays} onChange={(e) => setExpiresInDays(e.target.value)} placeholder={t('mcp.neverExpires')} />
-              </div>
-              <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-secondary)', fontSize: '0.82rem', cursor: 'pointer', paddingBottom: '0.55rem' }}>
-                <input type="checkbox" checked={readOnly} onChange={(e) => setReadOnly(e.target.checked)} />
-                <ShieldLock size={13} /> {t('mcp.readOnlyLabel')}
-              </label>
-            </div>
-            <button style={{ ...btnPrimary, marginTop: '0.8rem', opacity: creating ? 0.6 : 1 }} onClick={handleCreate} disabled={creating}>
-              {creating ? <Spinner animation="border" size="sm" /> : <PlusLg size={15} />}
-              {t('mcp.createToken')}
-            </button>
-          </div>
-
-          {/* Token list */}
-          <div style={{ ...card, marginBottom: 0 }}>
-            <h3 style={sectionTitle}>{t('mcp.tokensTitle')}</h3>
-            {tokens === null && (
-              <div style={{ textAlign: 'center', padding: '1rem' }}><Spinner animation="border" size="sm" style={{ color: 'var(--text-muted)' }} /></div>
+            <h3 style={sectionTitle}>{t('mcp.grantsTitle')}</h3>
+            {grants === null && (
+              <div style={{ textAlign: 'center', padding: '0.8rem' }}><Spinner animation="border" size="sm" style={{ color: 'var(--text-muted)' }} /></div>
             )}
-            {tokens && tokens.length === 0 && (
-              <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', margin: 0 }}>{t('mcp.noTokens')}</p>
+            {grants && grants.length === 0 && (
+              <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', margin: 0 }}>{t('mcp.noGrants')}</p>
             )}
-            {tokens && tokens.map((tk) => (
+            {grants && grants.map((g) => (
               <div
-                key={tk.id}
+                key={g.id}
                 style={{
                   display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.6rem',
                   padding: '0.6rem 0', borderBottom: '1px solid var(--border-subtle)',
                 }}
               >
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <span style={{ color: 'var(--text-primary)', fontSize: '0.88rem', fontWeight: 600 }}>{tk.label}</span>
-                    <span style={{
-                      fontSize: '0.68rem', padding: '0.1rem 0.4rem', borderRadius: 'var(--radius-sm)',
-                      background: 'var(--bg-base)', border: '1px solid var(--border-subtle)', color: 'var(--text-muted)',
-                    }}>
-                      {tk.readOnly ? t('mcp.readOnlyBadge') : t('mcp.readWriteBadge')}
-                    </span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    <span style={{ color: 'var(--text-primary)', fontSize: '0.88rem', fontWeight: 600 }}>{g.clientName}</span>
+                    {(g.scopes || []).map((s) => (
+                      <span key={s} style={{
+                        fontSize: '0.68rem', padding: '0.1rem 0.4rem', borderRadius: 'var(--radius-sm)',
+                        background: 'var(--bg-base)', border: '1px solid var(--border-subtle)', color: 'var(--text-muted)',
+                      }}>{s}</span>
+                    ))}
                   </div>
-                  <div style={{ color: 'var(--text-muted)', fontSize: '0.74rem', marginTop: '0.15rem' }}>
-                    {t('mcp.createdOn', { date: fmtDate(tk.createdAt) })}
-                    {tk.lastUsedAt && ` · ${t('mcp.lastUsed', { date: fmtDate(tk.lastUsedAt) })}`}
-                    {tk.expiresAt
-                      ? ` · ${t('mcp.expiresOn', { date: fmtDate(tk.expiresAt) })}`
-                      : ` · ${t('mcp.neverExpiresLabel')}`}
-                  </div>
+                  {g.authorizedAt && (
+                    <div style={{ color: 'var(--text-muted)', fontSize: '0.74rem', marginTop: '0.15rem' }}>
+                      {t('mcp.authorizedOn', { date: fmtDate(g.authorizedAt) })}
+                    </div>
+                  )}
                 </div>
                 <button
                   style={{ ...iconBtn, color: 'var(--danger)', borderColor: 'var(--danger-subtle)', flexShrink: 0 }}
-                  onClick={() => handleRevoke(tk.id)}
+                  onClick={() => handleRevokeGrant(g.id)}
                 >
                   <Trash size={13} /> {t('mcp.revoke')}
                 </button>
               </div>
             ))}
+          </div>
+
+          {/* ── Advanced / legacy: dt_mcp_ token + mcp-remote ───────────────── */}
+          <div style={{ ...card, marginBottom: 0 }}>
+            <button
+              onClick={toggleLegacy}
+              style={{
+                ...sectionTitle, background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+                display: 'flex', alignItems: 'center', gap: '0.4rem', width: '100%', marginBottom: legacyOpen ? '0.8rem' : 0,
+              }}
+            >
+              {legacyOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              {t('mcp.legacyTitle')}
+            </button>
+
+            {legacyOpen && (
+              <>
+                <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem', margin: '0 0 1rem' }}>{t('mcp.legacyHelp')}</p>
+
+                {/* One-time new token banner */}
+                {newToken && (
+                  <div style={{ ...card, borderColor: 'var(--accent-border)', background: 'var(--accent-subtle)' }}>
+                    <h3 style={{ ...sectionTitle, marginBottom: '0.35rem' }}>{t('mcp.tokenCreatedTitle')}</h3>
+                    <p style={{ color: 'var(--text-secondary)', fontSize: '0.82rem', margin: '0 0 0.6rem' }}>
+                      {t('mcp.tokenCreatedWarning')}
+                    </p>
+                    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                      <code style={{ ...codeBox, flex: 1, whiteSpace: 'nowrap' }}>{newToken}</code>
+                      <button style={iconBtn} onClick={() => copy(newToken, t('mcp.tokenCopied'))}>
+                        <Clipboard size={13} /> {t('mcp.copy')}
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Config snippet */}
+                <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem', display: 'block', marginBottom: '0.3rem' }}>
+                  {t('mcp.snippetTitle')}
+                </label>
+                <p style={{ color: 'var(--text-muted)', fontSize: '0.78rem', margin: '0 0 0.4rem' }}>{t('mcp.snippetHelp')}</p>
+                <div style={{ position: 'relative', marginBottom: '1rem' }}>
+                  <pre style={codeBox}>{buildSnippet(newToken || t('mcp.tokenPlaceholder'))}</pre>
+                  <button
+                    style={{ ...iconBtn, position: 'absolute', top: 8, right: 8 }}
+                    onClick={() => copy(buildSnippet(newToken || t('mcp.tokenPlaceholder')))}
+                  >
+                    <Clipboard size={13} /> {t('mcp.copy')}
+                  </button>
+                </div>
+
+                {/* Create token */}
+                <h3 style={sectionTitle}>{t('mcp.newTokenTitle')}</h3>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem', alignItems: 'flex-end' }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', flex: '1 1 200px' }}>
+                    <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>{t('mcp.labelField')}</label>
+                    <input style={input} value={label} onChange={(e) => setLabel(e.target.value)} placeholder={t('mcp.labelPlaceholder')} />
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', width: 140 }}>
+                    <label style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>{t('mcp.expiresField')}</label>
+                    <input style={input} type="number" min="1" value={expiresInDays} onChange={(e) => setExpiresInDays(e.target.value)} placeholder={t('mcp.neverExpires')} />
+                  </div>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-secondary)', fontSize: '0.82rem', cursor: 'pointer', paddingBottom: '0.55rem' }}>
+                    <input type="checkbox" checked={readOnly} onChange={(e) => setReadOnly(e.target.checked)} />
+                    <ShieldLock size={13} /> {t('mcp.readOnlyLabel')}
+                  </label>
+                </div>
+                <button style={{ ...btnPrimary, marginTop: '0.8rem', opacity: creating ? 0.6 : 1 }} onClick={handleCreate} disabled={creating}>
+                  {creating ? <Spinner animation="border" size="sm" /> : <PlusLg size={15} />}
+                  {t('mcp.createToken')}
+                </button>
+
+                {/* Token list */}
+                <h3 style={{ ...sectionTitle, marginTop: '1.2rem' }}>{t('mcp.tokensTitle')}</h3>
+                {tokens === null && (
+                  <div style={{ textAlign: 'center', padding: '1rem' }}><Spinner animation="border" size="sm" style={{ color: 'var(--text-muted)' }} /></div>
+                )}
+                {tokens && tokens.length === 0 && (
+                  <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', margin: 0 }}>{t('mcp.noTokens')}</p>
+                )}
+                {tokens && tokens.map((tk) => (
+                  <div
+                    key={tk.id}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.6rem',
+                      padding: '0.6rem 0', borderBottom: '1px solid var(--border-subtle)',
+                    }}
+                  >
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <span style={{ color: 'var(--text-primary)', fontSize: '0.88rem', fontWeight: 600 }}>{tk.label}</span>
+                        <span style={{
+                          fontSize: '0.68rem', padding: '0.1rem 0.4rem', borderRadius: 'var(--radius-sm)',
+                          background: 'var(--bg-base)', border: '1px solid var(--border-subtle)', color: 'var(--text-muted)',
+                        }}>
+                          {tk.readOnly ? t('mcp.readOnlyBadge') : t('mcp.readWriteBadge')}
+                        </span>
+                      </div>
+                      <div style={{ color: 'var(--text-muted)', fontSize: '0.74rem', marginTop: '0.15rem' }}>
+                        {t('mcp.createdOn', { date: fmtDate(tk.createdAt) })}
+                        {tk.lastUsedAt && ` · ${t('mcp.lastUsed', { date: fmtDate(tk.lastUsedAt) })}`}
+                        {tk.expiresAt
+                          ? ` · ${t('mcp.expiresOn', { date: fmtDate(tk.expiresAt) })}`
+                          : ` · ${t('mcp.neverExpiresLabel')}`}
+                      </div>
+                    </div>
+                    <button
+                      style={{ ...iconBtn, color: 'var(--danger)', borderColor: 'var(--danger-subtle)', flexShrink: 0 }}
+                      onClick={() => handleRevoke(tk.id)}
+                    >
+                      <Trash size={13} /> {t('mcp.revoke')}
+                    </button>
+                  </div>
+                ))}
+              </>
+            )}
           </div>
         </Modal.Body>
       </div>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -632,6 +632,31 @@
     "tokenCreatedWarning": "Copy it now — this token won't be shown again.",
     "tokenCreatedToast": "Token generated.",
     "tokenCopied": "Token copied.",
-    "dismiss": "Done, copied"
+    "dismiss": "Done, copied",
+    "connectTitle": "Connect in Claude (native connector)",
+    "connectHelp": "Paste the URL below into 'Add custom connector'. Authorization opens in your browser — no token to paste.",
+    "connectStep1": "In Claude, open Settings → Connectors → Add custom connector.",
+    "connectStep2": "Paste the MCP URL below and confirm.",
+    "connectStep3": "Log in and authorize read/write access to your tasks.",
+    "grantsTitle": "Authorized apps",
+    "noGrants": "No app connected via OAuth yet.",
+    "authorizedOn": "Authorized on {{date}}",
+    "grantRevokeConfirm": "Revoke this app's access? It will need to authorize again.",
+    "grantRevoked": "Access revoked.",
+    "legacyTitle": "Advanced: manual token (mcp-remote)",
+    "legacyHelp": "Alternative for clients without OAuth (e.g. Claude Desktop via mcp-remote). Generate a token and paste it in the Authorization header."
+  },
+  "oauthConsent": {
+    "title": "Authorize access",
+    "subtitle": "{{client}} wants to access your DailyTracker account.",
+    "permissionsLabel": "Requested permissions:",
+    "scopeRead": "View your tasks, projects and stages",
+    "scopeWrite": "Create and edit tasks",
+    "approve": "Authorize",
+    "deny": "Deny",
+    "needScope": "Select at least one permission.",
+    "invalidRequest": "Invalid or incomplete authorization request.",
+    "errorTitle": "Could not authorize",
+    "backToApp": "Back to app"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -632,6 +632,31 @@
     "tokenCreatedWarning": "Cópialo ahora — este token no se mostrará de nuevo.",
     "tokenCreatedToast": "Token generado.",
     "tokenCopied": "Token copiado.",
-    "dismiss": "Listo, copiado"
+    "dismiss": "Listo, copiado",
+    "connectTitle": "Conectar en Claude (conector nativo)",
+    "connectHelp": "Pega la URL de abajo en 'Añadir conector personalizado'. La autorización se abre en el navegador — sin pegar ningún token.",
+    "connectStep1": "En Claude, abre Ajustes → Conectores → Añadir conector personalizado.",
+    "connectStep2": "Pega la URL del MCP de abajo y confirma.",
+    "connectStep3": "Inicia sesión y autoriza el acceso de lectura/escritura a tus tareas.",
+    "grantsTitle": "Apps autorizadas",
+    "noGrants": "Aún no hay ninguna app conectada por OAuth.",
+    "authorizedOn": "Autorizado el {{date}}",
+    "grantRevokeConfirm": "¿Revocar el acceso de esta app? Tendrá que autorizar de nuevo.",
+    "grantRevoked": "Acceso revocado.",
+    "legacyTitle": "Avanzado: token manual (mcp-remote)",
+    "legacyHelp": "Alternativa para clientes sin OAuth (p. ej. Claude Desktop vía mcp-remote). Genera un token y pégalo en el header Authorization."
+  },
+  "oauthConsent": {
+    "title": "Autorizar acceso",
+    "subtitle": "{{client}} quiere acceder a tu cuenta de DailyTracker.",
+    "permissionsLabel": "Permisos solicitados:",
+    "scopeRead": "Ver tus tareas, proyectos y etapas",
+    "scopeWrite": "Crear y editar tareas",
+    "approve": "Autorizar",
+    "deny": "Rechazar",
+    "needScope": "Selecciona al menos un permiso.",
+    "invalidRequest": "Solicitud de autorización inválida o incompleta.",
+    "errorTitle": "No se pudo autorizar",
+    "backToApp": "Volver a la app"
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -632,6 +632,31 @@
     "tokenCreatedWarning": "Copie agora — este token não será exibido novamente.",
     "tokenCreatedToast": "Token gerado.",
     "tokenCopied": "Token copiado.",
-    "dismiss": "Ok, copiei"
+    "dismiss": "Ok, copiei",
+    "connectTitle": "Conectar no Claude (conector nativo)",
+    "connectHelp": "Cole a URL abaixo em 'Adicionar conector personalizado'. A autorização abre no navegador — sem precisar colar token.",
+    "connectStep1": "No Claude, abra Configurações → Conectores → Adicionar conector personalizado.",
+    "connectStep2": "Cole a URL do MCP abaixo e confirme.",
+    "connectStep3": "Faça login e autorize o acesso de leitura/escrita às suas tarefas.",
+    "grantsTitle": "Apps autorizados",
+    "noGrants": "Nenhum app conectado via OAuth ainda.",
+    "authorizedOn": "Autorizado em {{date}}",
+    "grantRevokeConfirm": "Revogar o acesso deste app? Ele precisará autorizar novamente.",
+    "grantRevoked": "Acesso revogado.",
+    "legacyTitle": "Avançado: token manual (mcp-remote)",
+    "legacyHelp": "Alternativa para clientes sem OAuth (ex: Claude Desktop via mcp-remote). Gere um token e cole no header Authorization."
+  },
+  "oauthConsent": {
+    "title": "Autorizar acesso",
+    "subtitle": "{{client}} quer acessar sua conta DailyTracker.",
+    "permissionsLabel": "Permissões solicitadas:",
+    "scopeRead": "Ver suas tarefas, projetos e etapas",
+    "scopeWrite": "Criar e editar tarefas",
+    "approve": "Autorizar",
+    "deny": "Recusar",
+    "needScope": "Selecione ao menos uma permissão.",
+    "invalidRequest": "Pedido de autorização inválido ou incompleto.",
+    "errorTitle": "Não foi possível autorizar",
+    "backToApp": "Voltar ao app"
   }
 }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import api from '../services/api';
 import { toast } from 'sonner';
@@ -16,6 +16,10 @@ export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  // Return target after login (e.g. the OAuth consent page). Same-origin paths only.
+  const nextParam = searchParams.get('next');
+  const destination = nextParam && nextParam.startsWith('/') ? nextParam : '/dashboard';
 
   useEffect(() => {
     const handleMessage = (event) => {
@@ -29,14 +33,14 @@ export default function LoginPage() {
           localStorage.setItem('refreshToken', refreshToken);
         }
         toast.success(t('login.googleSuccessToast'));
-        navigate('/dashboard');
+        navigate(destination);
       } else if (error) {
         toast.error(t('login.googleErrorToast'));
       }
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [navigate]);
+  }, [navigate, destination]);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -58,7 +62,7 @@ export default function LoginPage() {
         sessionStorage.removeItem('pendingInviteToken');
       }
       toast.success(t('login.successToast'));
-      navigate('/dashboard');
+      navigate(destination);
     } catch (err) {
       const msg = err.response?.data?.error || t('login.invalidCredentials');
       toast.error(msg);

--- a/src/pages/OAuthConsent.jsx
+++ b/src/pages/OAuthConsent.jsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Spinner } from 'react-bootstrap';
+import Robot from 'react-bootstrap-icons/dist/icons/robot';
+import ShieldLock from 'react-bootstrap-icons/dist/icons/shield-lock';
+import { toast } from 'sonner';
+import api from '../services/api';
+import CssParticles from '../components/CssParticles';
+
+const SCOPE_META = {
+  'mcp:read': { key: 'oauthConsent.scopeRead', locked: false },
+  'mcp:write': { key: 'oauthConsent.scopeWrite', locked: false },
+};
+
+/**
+ * OAuth 2.1 consent page. The API's Authorization Server bounces an unauthenticated
+ * /oauth2/authorize hit here (preserving the query string). The logged-in user picks read/write,
+ * and we POST the approval to mint a one-time ticket, then top-level navigate to the resume URL so
+ * the Authorization Server can issue the code back to the connector (e.g. Claude).
+ */
+export default function OAuthConsent() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const params = useMemo(() => Object.fromEntries(searchParams.entries()), [searchParams]);
+  const requestedScopes = useMemo(
+    () => (params.scope ? params.scope.trim().split(/[\s+]+/).filter(Boolean) : []),
+    [params.scope],
+  );
+
+  const [info, setInfo] = useState(null);
+  const [approved, setApproved] = useState(() => new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Require login; bounce to /login and come back here afterwards.
+  useEffect(() => {
+    if (!localStorage.getItem('authToken')) {
+      const next = encodeURIComponent(window.location.pathname + window.location.search);
+      navigate(`/login?next=${next}`, { replace: true });
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!params.client_id) {
+      setError(t('oauthConsent.invalidRequest'));
+      return;
+    }
+    api
+      .get('/api/oauth/consent-info', { params: { client_id: params.client_id, scope: params.scope } })
+      .then((res) => {
+        setInfo(res.data);
+        setApproved(new Set(res.data.requestedScopes || requestedScopes));
+      })
+      .catch(() => setError(t('oauthConsent.invalidRequest')));
+  }, [params.client_id, params.scope, requestedScopes, t]);
+
+  const toggle = (scope) => {
+    setApproved((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
+      return next;
+    });
+  };
+
+  const handleApprove = async () => {
+    if (approved.size === 0) {
+      toast.error(t('oauthConsent.needScope'));
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await api.post('/api/oauth/consent', {
+        params,
+        approvedScopes: Array.from(approved),
+      });
+      window.location.href = res.data.resumeUrl;
+    } catch {
+      setSubmitting(false);
+      /* interceptor toasts the error */
+    }
+  };
+
+  const handleDeny = () => {
+    if (params.redirect_uri) {
+      const url = new URL(params.redirect_uri);
+      url.searchParams.set('error', 'access_denied');
+      if (params.state) url.searchParams.set('state', params.state);
+      window.location.href = url.toString();
+    } else {
+      navigate('/dashboard', { replace: true });
+    }
+  };
+
+  const scopeList = (info?.requestedScopes && info.requestedScopes.length > 0)
+    ? info.requestedScopes
+    : requestedScopes;
+
+  const shell = (children) => (
+    <div style={{
+      position: 'relative', width: '100vw', minHeight: '100vh', backgroundColor: 'var(--bg-base)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', padding: '1.5rem',
+    }}>
+      <CssParticles />
+      <div className="animate-fade-in-up delay-1" style={{ width: '100%', maxWidth: '440px' }}>
+        {children}
+      </div>
+    </div>
+  );
+
+  const card = {
+    padding: '2rem',
+    backgroundColor: 'var(--bg-surface)',
+    border: '1px solid var(--border-subtle)',
+    borderRadius: 'var(--radius-lg)',
+  };
+
+  if (error) {
+    return shell(
+      <div style={card}>
+        <h1 style={{ fontFamily: 'var(--font-display)', fontSize: '1.2rem', color: 'var(--text-primary)', marginTop: 0 }}>
+          {t('oauthConsent.errorTitle')}
+        </h1>
+        <p style={{ color: 'var(--text-muted)', fontSize: '0.88rem' }}>{error}</p>
+        <button style={secondaryBtn} onClick={() => navigate('/dashboard', { replace: true })}>
+          {t('oauthConsent.backToApp')}
+        </button>
+      </div>,
+    );
+  }
+
+  if (!info) {
+    return shell(
+      <div style={{ ...card, textAlign: 'center' }}>
+        <Spinner animation="border" variant="success" />
+      </div>,
+    );
+  }
+
+  return shell(
+    <div style={card}>
+      <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+        <div style={{
+          width: 48, height: 48, borderRadius: '50%', background: 'var(--accent-subtle)',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center', color: 'var(--accent)',
+        }}>
+          <Robot size={24} />
+        </div>
+        <h1 style={{ fontFamily: 'var(--font-display)', fontSize: '1.25rem', color: 'var(--text-primary)', margin: '0.9rem 0 0.3rem' }}>
+          {t('oauthConsent.title')}
+        </h1>
+        <p style={{ color: 'var(--text-muted)', fontSize: '0.88rem', margin: 0 }}>
+          {t('oauthConsent.subtitle', { client: info.clientName })}
+        </p>
+      </div>
+
+      <div style={{ marginBottom: '1.25rem' }}>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.82rem', margin: '0 0 0.6rem' }}>
+          {t('oauthConsent.permissionsLabel')}
+        </p>
+        {scopeList.map((scope) => {
+          const meta = SCOPE_META[scope];
+          return (
+            <label
+              key={scope}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.6rem', padding: '0.7rem 0.8rem',
+                border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)',
+                marginBottom: '0.5rem', cursor: 'pointer', background: 'var(--bg-base)',
+              }}
+            >
+              <input type="checkbox" checked={approved.has(scope)} onChange={() => toggle(scope)} />
+              <ShieldLock size={15} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+              <span style={{ color: 'var(--text-primary)', fontSize: '0.86rem' }}>
+                {meta ? t(meta.key) : scope}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.6rem' }}>
+        <button style={{ ...secondaryBtn, flex: 1 }} onClick={handleDeny} disabled={submitting}>
+          {t('oauthConsent.deny')}
+        </button>
+        <button style={{ ...primaryBtn, flex: 1, opacity: submitting ? 0.6 : 1 }} onClick={handleApprove} disabled={submitting}>
+          {submitting ? <Spinner animation="border" size="sm" /> : t('oauthConsent.approve')}
+        </button>
+      </div>
+    </div>,
+  );
+}
+
+const primaryBtn = {
+  padding: '0.6rem 0.9rem',
+  backgroundColor: 'var(--accent)',
+  color: 'var(--bg-base)',
+  border: 'none',
+  borderRadius: 'var(--radius-md)',
+  fontSize: '0.88rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.4rem',
+};
+
+const secondaryBtn = {
+  padding: '0.6rem 0.9rem',
+  backgroundColor: 'transparent',
+  color: 'var(--text-secondary)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-md)',
+  fontSize: '0.88rem',
+  fontWeight: 500,
+  cursor: 'pointer',
+};


### PR DESCRIPTION
## O que

Frontend do fluxo OAuth 2.1 do MCP: página de consent + painel MCP reorientado pro conector nativo.

## Mudanças

- **`OAuthConsent` page** (`/oauth/consent`): aprovação do resource-owner (escopos read/write). `LoginPage` honra `?next=` pra voltar aqui após login
- **`McpModal`**: "add custom connector" (OAuth) como caminho primário + lista/revoga apps autorizados; painel de token `dt_mcp_` vira seção legada colapsável; fix da URL de conexão `/mcp/sse` → `/mcp`
- **i18n** (pt-BR/en-US/es) pros textos novos de consent + conector

## Build

`npm run build` EXIT 0.

## Deploy

Buildar com `VITE_API_URL=https://api.dailytracker.com.br`. Rota `/oauth/consent` precisa existir no deploy pro consent funcionar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)